### PR TITLE
Debug symbols added to the V8 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN cp -rf include ./target
 RUN find target -name "libv8_for_testing.cr.so" -delete
 
 # stl lib from android-ndk have no symbols, so why bother copy them?
-RUN find target/symbols -name "libc++shared.so" -delete
+RUN find target/symbols -name "libc++_shared.so" -delete
 
 RUN zip -r v8.zip target
 RUN ls -al /home/docker/v8/v8.zip

--- a/args_arm.gn
+++ b/args_arm.gn
@@ -8,8 +8,6 @@ use_goma = false
 v8_use_snapshot = true
 v8_use_external_startup_data = false
 v8_static_library = false
-strip_absolute_paths_from_debug_symbols = true
-strip_debug_info = true 
-symbol_level=0
-
-
+strip_absolute_paths_from_debug_symbols = false
+strip_debug_info = false
+symbol_level=1

--- a/args_arm64.gn
+++ b/args_arm64.gn
@@ -8,8 +8,6 @@ use_goma = false
 v8_use_snapshot = true
 v8_use_external_startup_data = false
 v8_static_library = false
-strip_absolute_paths_from_debug_symbols = true
-strip_debug_info = true 
-symbol_level=0
-
-
+strip_absolute_paths_from_debug_symbols = false
+strip_debug_info = false
+symbol_level=1

--- a/args_x86.gn
+++ b/args_x86.gn
@@ -8,8 +8,6 @@ use_goma = false
 v8_use_snapshot = true
 v8_use_external_startup_data = false
 v8_static_library = false
-strip_absolute_paths_from_debug_symbols = true
-strip_debug_info = true 
-symbol_level=0
-
-
+strip_absolute_paths_from_debug_symbols = false
+strip_debug_info = false
+symbol_level=1


### PR DESCRIPTION
Debug info added to the symbols.
Turns out there are multiple configuration options in V8 to enable debug symbols:
symbol_level - 0|1|2

- 0 No symbols
- 1 line-tables-only
- 2 full debug info needed for crashdump analysis

For our purpose level 1 is good enough as it allows us to unwind stack-traces, so we can save some build time.
It's worth to mention that in case of the usage of the single shared library the symbol_level will be downgraded anyway see: https://bugs.chromium.org/p/chromium/issues/detail?id=648948

strip_debug_info - if set to false this option overrides No symbols, well symbols are generated for the *.o files and take place on the disk but stripped out even from the unstripped library.

strip_absolute_paths_from_debug_symbols - is not required option but it doesn't hurt to have it.

